### PR TITLE
Feat/#78

### DIFF
--- a/src/main/java/com/prgrms/offer/OfferApplication.java
+++ b/src/main/java/com/prgrms/offer/OfferApplication.java
@@ -3,8 +3,16 @@ package com.prgrms.offer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class OfferApplication {
+
+    @PostConstruct
+    void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(OfferApplication.class, args);

--- a/src/main/java/com/prgrms/offer/domain/offer/model/dto/OfferResponse.java
+++ b/src/main/java/com/prgrms/offer/domain/offer/model/dto/OfferResponse.java
@@ -43,5 +43,7 @@ public class OfferResponse {
         private final String nickname;
 
         private final String address;
+
+        private final int offerLevel;
     }
 }

--- a/src/main/java/com/prgrms/offer/domain/offer/service/OfferConverter.java
+++ b/src/main/java/com/prgrms/offer/domain/offer/service/OfferConverter.java
@@ -28,7 +28,7 @@ public class OfferConverter {
                 .id(offer.getId())
                 .offerer(
                         new OfferResponse.OffererDto(
-                                offerer.getId(), offerer.getNickname(), offerer.getAddress()
+                                offerer.getId(), offerer.getNickname(), offerer.getAddress(), offerer.getOfferLevel()
                         )
                 )
                 .articleId(offer.getArticle().getId())
@@ -47,7 +47,7 @@ public class OfferConverter {
                 .id(offer.getId())
                 .offerer(
                         new OfferResponse.OffererDto(
-                                offerer.getId(), offerer.getNickname(), offerer.getAddress()
+                                offerer.getId(), offerer.getNickname(), offerer.getAddress(), offerer.getOfferLevel()
                         )
                 )
                 .articleId(offer.getArticle().getId())


### PR DESCRIPTION
resolve #78 

- 스프링부트 애플리케이션 실행 타임존 서울 시간으로 지정
- offer 페이징 반환시 offerer의 offerlevel 추가