### PR TITLE
[쪽지] MessageRoom 정렬 방식 수정, 페이징 정보 반환 - Feat/#89

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/message/controller/MessageController.java
+++ b/src/main/java/com/prgrms/offer/domain/message/controller/MessageController.java
@@ -104,13 +104,12 @@ public class MessageController {
 
         return ResponseEntity.ok(
             ApiResponse.of(
-                ResponseMessage.SUCCESS, messageContentResponsePage
-//                PageDto.of(
-//                    messageContentResponsePage.getContent(), pageInfo
-//                )
+                ResponseMessage.SUCCESS,
+                PageDto.of(
+                    messageContentResponsePage.getContent(), pageInfo
+                )
             )
         );
-
     }
 
     @GetMapping("/messageRoom/{messageRoomId}/messageRoomInfo")

--- a/src/main/java/com/prgrms/offer/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/message/repository/MessageRepository.java
@@ -3,7 +3,6 @@ package com.prgrms.offer.domain.message.repository;
 import com.prgrms.offer.domain.message.model.entity.Message;
 import com.prgrms.offer.domain.message.model.entity.MessageRoom;
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
@@ -14,4 +13,7 @@ public interface MessageRepository extends Repository<Message, Long> {
     Message findTop1ByMessageRoomOrderByCreatedDateDesc(MessageRoom messageRoom);
 
     List<Message> findByMessageRoomOrderByMessageIdDesc(MessageRoom messageRoom, Pageable pageable);
+
+    Long countAllByMessageRoom(MessageRoom messageRoom);
+
 }

--- a/src/main/java/com/prgrms/offer/domain/message/repository/MessageRoomRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/message/repository/MessageRoomRepository.java
@@ -20,8 +20,8 @@ public interface MessageRoomRepository extends Repository<MessageRoom, Long> {
 
     Optional<MessageRoom> findById(long messageRoomId);
 
-    Optional<MessageRoom> findByMember(Member member);
-
     Optional<MessageRoom> findByMemberAndOffer(Member messagePartner, Offer offer);
+
+    Long countMessageRoomByMember(Member me);
 
 }

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageConverter.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageConverter.java
@@ -39,7 +39,7 @@ public class MessageConverter {
 
 
     public Page<MessageContentResponse> toMessageContentResponsePage(
-        List<Message> messageList, Pageable pageable) {
+        List<Message> messageList, long numMessage, Pageable pageable) {
 
         List<MessageContentResponse> messageContentResponseList =
             messageList.stream().map(e -> new MessageContentResponse(
@@ -51,16 +51,10 @@ public class MessageConverter {
                 )
                 .collect(Collectors.toList());
 
-        final int start = (int) pageable.getOffset();
-
-        final int end = Math.min((start + pageable.getPageSize()),
-            messageContentResponseList.size());
-
         messageContentResponseList.sort(messageContentResponseComparator);
 
-        final Page<MessageContentResponse> page = new PageImpl<>(
-            messageContentResponseList, pageable,
-            messageContentResponseList.size());
+        final Page<MessageContentResponse> page =
+            new PageImpl<>(messageContentResponseList, pageable, numMessage);
 
         return page;
     }

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageRoomConverter.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageRoomConverter.java
@@ -33,6 +33,7 @@ public class MessageRoomConverter {
     public Page<MessageRoomResponse> toMessageRoomResponsePage(
         List<MessageRoom> messageRoomList,
         List<Message> messageList,
+        long numMessageRoom,
         Pageable pageable) {
 
         List<MessageRoomResponse> messageRoomResponseList = new ArrayList<>();
@@ -46,9 +47,8 @@ public class MessageRoomConverter {
             );
         }
 
-        final int start = (int)pageable.getOffset();
-        final int end = Math.min((start + pageable.getPageSize()), messageRoomResponseList.size());
-        final Page<MessageRoomResponse> page = new PageImpl<>(messageRoomResponseList.subList(start, end), pageable, messageRoomResponseList.size());
+        final Page<MessageRoomResponse> page = new PageImpl<>(
+            messageRoomResponseList, pageable, numMessageRoom);
 
         return page;
     }

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
@@ -94,8 +94,10 @@ public class MessageService {
             messageRoom -> messageRepository.findTop1ByMessageRoomOrderByCreatedDateDesc(
                 messageRoom)).collect(Collectors.toList());
 
+        long numMessageRoom = messageRoomRepository.countMessageRoomByMember(me);
+
         Page<MessageRoomResponse> messageRoomResponsePage =
-            messageRoomConverter.toMessageRoomResponsePage(messageRoomList, messageList, pageable);
+            messageRoomConverter.toMessageRoomResponsePage(messageRoomList, messageList, numMessageRoom, pageable);
 
         return messageRoomResponsePage;
     }
@@ -155,8 +157,9 @@ public class MessageService {
             .orElseThrow(() -> new BusinessException(ResponseMessage.MESSAGE_ROOM_NOT_FOUND));
 
         List<Message> messageList = messageRepository.findByMessageRoomOrderByMessageIdDesc(myMessageRoom, pageable);
+        long numMessage = messageRepository.countAllByMessageRoom(myMessageRoom);
 
-        return messageConverter.toMessageContentResponsePage(messageList, pageable);
+        return messageConverter.toMessageContentResponsePage(messageList, numMessage, pageable);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- MessageRoom 정렬+페이징 방식 수정
  + 1번 페이지 부터 최신의 대화 내용으로 정렬
  + 페이지 내 대화 내용은 시간 오름차순
- message contents,  message box 조회시 올바른 paging 정보 반환하도록 수정

resolve #89 