### PR TITLE
[검색] fix: 로직상 오류 수정 Feat/#110

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/src/main/java/com/prgrms/offer/domain/article/repository/CustomizedArticleRepositoryImpl.java
@@ -52,7 +52,7 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
             if (maxPrice != null) {
                 return article.price.between(minPrice, maxPrice);
             }
-            return article.price.goe(maxPrice);
+            return article.price.goe(minPrice);
         }
 
         if (maxPrice != null) {


### PR DESCRIPTION
- 검색 필터 중 minPrice를 입력하고 maxPrice를 입력하지 않은 경우 500 Error (NPE) 발생 
  + 로직상 매개변수 잘못 사용함(minPrice 대신 maxPrice를 사용)

resolves #112 