### PR TITLE
hotfix: sql문 오류 - 좋아요한 article 검색시 500에러 발생 Feat/#115

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/article/repository/ArticleRepository.java
@@ -35,9 +35,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Customi
     long countArticlesByWriter(Member member);
 
     @Query(value = "select * from article where article_id in (select like_article.article_id from like_article where member_id = ?1)" +
-            "and (trade_status_code = 2 or trade_status_code 4)",
+            "and (trade_status_code = 2 or trade_status_code = 4)",
             countQuery = "select count(*) from article where article_id in (select like_article.article_id from like_article where member_id = ?1)" +
-                    "and (trade_status_code = 2 or trade_status_code 4)",
+                    "and (trade_status_code = 2 or trade_status_code = 4)",
             nativeQuery = true)
     Page<Article> findLikedSellingArticleByMember(long memberId, Pageable pageable);
 


### PR DESCRIPTION
sql 문법 오류로
좋아요한 article 검색시 500에러 발생