### PR TITLE
hotfix: 좋아요한 게시글 조회 관련 Feat/#115

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/article/repository/ArticleRepository.java
@@ -35,9 +35,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Customi
     long countArticlesByWriter(Member member);
 
     @Query(value = "select * from article where article_id in (select like_article.article_id from like_article where member_id = ?1)" +
-            "and (trade_status_code = 2 or trade_status_code 4)",
+            "and (trade_status_code = 2 or trade_status_code = 4)",
             countQuery = "select count(*) from article where article_id in (select like_article.article_id from like_article where member_id = ?1)" +
-                    "and (trade_status_code = 2 or trade_status_code 4)",
+                    "and (trade_status_code = 2 or trade_status_code = 4)",
             nativeQuery = true)
     Page<Article> findLikedSellingArticleByMember(long memberId, Pageable pageable);
 

--- a/src/main/java/com/prgrms/offer/domain/article/service/ArticleService.java
+++ b/src/main/java/com/prgrms/offer/domain/article/service/ArticleService.java
@@ -290,7 +290,7 @@ public class ArticleService {
 
         if (tradeStatusCode == TradeStatus.COMPLETED.getCode()) {
             return articleRepository
-                    .findLikedSellingArticleByMember(member.getId(), pageable)
+                    .findLikedCompletedArticleByMember(member.getId(), pageable)
                     .map(p -> makeBriefViewResponseWithLikeInfo(p, member));
         } else {
             return articleRepository


### PR DESCRIPTION
- 좋아요한 게시글 조회시 500에러 발생
: sql 쿼리 문법오류
- 좋아요한 게시글 중 판매 완료된 상품(게시글) 조회시 판매중/예약중인 게시글이 조회되는 에러
: findLikedSellingArticleByMember() 메서드가 (내가 찜한) 판매 완료된 게시글 조회에도 중복으로 사용됨

resolves #115 