### PR TITLE
fix: messageRoom 정렬 Feat/#114

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/message/model/dto/MessageRoomResponse.java
+++ b/src/main/java/com/prgrms/offer/domain/message/model/dto/MessageRoomResponse.java
@@ -42,6 +42,7 @@ public class MessageRoomResponse {
         }
     }
 
+    @Getter
     @AllArgsConstructor
     @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public static class MessageInfo {

--- a/src/main/java/com/prgrms/offer/domain/message/repository/MessageRoomRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/message/repository/MessageRoomRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.repository.Repository;
 
 public interface MessageRoomRepository extends Repository<MessageRoom, Long> {
 
-    List<MessageRoom> findByMemberIdOrderByCreatedDateDesc(Long userId, Pageable pageable);
+    List<MessageRoom> findByMemberId(Long userId, Pageable pageable);
 
     MessageRoom save(MessageRoom messageRoom);
 

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageRoomConverter.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageRoomConverter.java
@@ -7,6 +7,7 @@ import com.prgrms.offer.domain.message.model.dto.MessageRoomResponse.UserInfo;
 import com.prgrms.offer.domain.message.model.entity.Message;
 import com.prgrms.offer.domain.message.model.entity.MessageRoom;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MessageRoomConverter {
+
+    private final MessageRoomResponseComparator messageRoomComparator = new MessageRoomResponseComparator();
 
     public MessageRoomResponse toMessageRoomResponse(MessageRoom messageRoom, Message message) {
         Member messagePartner = messageRoom.getMessagePartner();
@@ -47,10 +50,22 @@ public class MessageRoomConverter {
             );
         }
 
+        messageRoomResponseList.sort(messageRoomComparator);
+
         final Page<MessageRoomResponse> page = new PageImpl<>(
             messageRoomResponseList, pageable, numMessageRoom);
 
         return page;
+    }
+
+    class MessageRoomResponseComparator implements Comparator<MessageRoomResponse> {
+
+        // 최신 쪽지 내역이 있는 messageRoom 내림차순 정렬
+        @Override
+        public int compare(MessageRoomResponse o1, MessageRoomResponse o2) {
+            return o1.getMessage().getCreatedDate().isAfter(o2.getMessage().getCreatedDate()) ? -1
+                : 1;
+        }
     }
 
 }

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
@@ -87,8 +87,7 @@ public class MessageService {
     public Page<MessageRoomResponse> getMessageBox(String loginId, Pageable pageable) {
         Member me = memberRepository.findByPrincipal(loginId).get();
 
-        List<MessageRoom> messageRoomList = messageRoomRepository.findByMemberIdOrderByCreatedDateDesc(
-            me.getId(), pageable);
+        List<MessageRoom> messageRoomList = messageRoomRepository.findByMemberId(me.getId(), pageable);
 
         List<Message> messageList = messageRoomList.stream().map(
             messageRoom -> messageRepository.findTop1ByMessageRoomOrderByCreatedDateDesc(

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
@@ -83,7 +83,7 @@ public class MessageService {
     }
 
     // 쪽지함 가져오기
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<MessageRoomResponse> getMessageBox(String loginId, Pageable pageable) {
         Member me = memberRepository.findByPrincipal(loginId).get();
 


### PR DESCRIPTION
- 최신 메시지가 발생한 messageRoom 순으로 내림차순 정렬
  - 기존 로직 : MessageRoomRepository의 findByMemberIdOrderByCreatedDateDesc()로 messageRoom을 조회하여 출력하는 방식은 messageRoom이 생성된 시각의 내림차순이므로 비즈니스 로직에 어긋하는 구현임
  - messageRoom의 message createdDate를 비교하는 comparator 인터페이스를  implement하여 기능 구현함

- 정렬 방식 수정에 따른 JPA 쿼리메서드 수정
  - MessageRoom을 member로 조회하여 Java code 단에서 정렬하도록 변경
  - OrderByCreatedDateDesc 를 하지 않아도 됨
  
- refactor
  - getMessageBox()에 @transactional(readOnly = true) 추가

resolves #114 