### PR TITLE
[Fix/검색] 아티클 검색시 판매 완료된 아티클(상품) 제외한 결과 반환 Feat/#123

### DIFF
--- a/src/main/java/com/prgrms/offer/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/article/repository/ArticleRepository.java
@@ -22,7 +22,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Customi
     @Override
     boolean existsById(Long aLong);
 
-    Page<Article> findByTitleIgnoreCaseContains(String title, Pageable pageable);
+    Page<Article> findByTitleIgnoreCaseContainsAndTradeStatusCodeIn(String title, Integer[] tradeStatusCodeArray, Pageable pageable);
 
     Page<Article> findAllByCategoryCode(Pageable pageable, int categoryCode);
 

--- a/src/main/java/com/prgrms/offer/domain/article/repository/CustomizedArticleRepository.java
+++ b/src/main/java/com/prgrms/offer/domain/article/repository/CustomizedArticleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface CustomizedArticleRepository {
 
-    List<Article> findByFilter(SearchFilterRequest searchFilterRequest, Pageable pageable);
+    List<Article> findByTradeStatusCodeInAndFilter(Integer[] tradeStatusCodeArray, SearchFilterRequest searchFilterRequest, Pageable pageable);
 
-    Long countAllByFilter(SearchFilterRequest searchFilterRequest);
+    Long countAllByTradeStatusCodeInAndFilter(Integer[] tradeStatusCodeArray, SearchFilterRequest searchFilterRequest);
 }

--- a/src/main/java/com/prgrms/offer/domain/article/repository/CustomizedArticleRepositoryImpl.java
+++ b/src/main/java/com/prgrms/offer/domain/article/repository/CustomizedArticleRepositoryImpl.java
@@ -3,13 +3,18 @@ package com.prgrms.offer.domain.article.repository;
 import static com.prgrms.offer.domain.article.model.entity.QArticle.article;
 
 import com.prgrms.offer.domain.article.model.entity.Article;
+import com.prgrms.offer.domain.article.model.value.TradeStatus;
 import com.prgrms.offer.domain.search.model.dto.SearchFilterRequest;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public class CustomizedArticleRepositoryImpl implements CustomizedArticleRepository {
+
+    private static final List<Integer> tradeStatusOnSaleOrBooked = Arrays.asList(
+        TradeStatus.ON_SALE.getCode(), TradeStatus.RESERVING.getCode());
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -18,10 +23,14 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
     }
 
     @Override
-    public List<Article> findByFilter(SearchFilterRequest searchFilterRequest, Pageable pageable) {
+    public List<Article> findByTradeStatusCodeInAndFilter(
+        Integer[] tradeStatusCodeArray,
+        SearchFilterRequest searchFilterRequest,
+        Pageable pageable) {
 
         return jpaQueryFactory.selectFrom(article)
-            .where(containsIgnoreTitle(searchFilterRequest.getTitle()),
+            .where(onSellingOrBooked(),
+                containsIgnoreTitle(searchFilterRequest.getTitle()),
                 eqCategory(searchFilterRequest.getCategory()),
                 eqTradeMethod(searchFilterRequest.getTradeMethod()),
                 priceInRange(searchFilterRequest.getMinPrice(), searchFilterRequest.getMaxPrice()))
@@ -29,10 +38,17 @@ public class CustomizedArticleRepositoryImpl implements CustomizedArticleReposit
     }
 
     @Override
-    public Long countAllByFilter(SearchFilterRequest searchFilterRequest) {
+    public Long countAllByTradeStatusCodeInAndFilter(
+        Integer[] tradeStatusCodeArray,
+        SearchFilterRequest searchFilterRequest) {
         return jpaQueryFactory.selectFrom(article)
-            .where(containsIgnoreTitle(searchFilterRequest.getTitle()),
+            .where(onSellingOrBooked(),
+                containsIgnoreTitle(searchFilterRequest.getTitle()),
                 eqCategory(searchFilterRequest.getCategory())).fetchCount();
+    }
+
+    private BooleanExpression onSellingOrBooked() {
+        return article.tradeStatusCode.in(tradeStatusOnSaleOrBooked);
     }
 
     private BooleanExpression containsIgnoreTitle(String title) {

--- a/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
+++ b/src/main/java/com/prgrms/offer/domain/message/service/MessageService.java
@@ -83,7 +83,7 @@ public class MessageService {
     }
 
     // 쪽지함 가져오기
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<MessageRoomResponse> getMessageBox(String loginId, Pageable pageable) {
         Member me = memberRepository.findByPrincipal(loginId).get();
 

--- a/src/main/java/com/prgrms/offer/domain/search/controller/ArticleSearchController.java
+++ b/src/main/java/com/prgrms/offer/domain/search/controller/ArticleSearchController.java
@@ -35,7 +35,7 @@ public class ArticleSearchController {
         Pageable pageable,
         @AuthenticationPrincipal JwtAuthentication authentication) {
         Page<ArticleBriefViewResponse> articleBriefViewResponse = articleSearchService.findByTitle(
-            title, pageable, authentication);
+            title, pageable, Optional.ofNullable(authentication));
 
         PageInfo pageInfo = getPageInfo(articleBriefViewResponse);
 

--- a/src/main/java/com/prgrms/offer/domain/search/service/ArticleSearchService.java
+++ b/src/main/java/com/prgrms/offer/domain/search/service/ArticleSearchService.java
@@ -30,6 +30,8 @@ public class ArticleSearchService {
     private final LikeArticleRepository likeArticleRepository;
     private final MemberRepository memberRepository;
 
+    private final Integer[] tradeStatusCodeArray = {2, 4};
+
     @Transactional(readOnly = true)
     public Page<ArticleBriefViewResponse> findByTitle(
         String title,
@@ -37,16 +39,17 @@ public class ArticleSearchService {
         @AuthenticationPrincipal JwtAuthentication authentication) {
 
         if (authentication == null) {
-            Page<ArticleBriefViewResponse> articleBriefViewResponses = articleRepository.findByTitleIgnoreCaseContains(
-                title, pageable).map(
+            Page<ArticleBriefViewResponse> articleBriefViewResponses = articleRepository.findByTitleIgnoreCaseContainsAndTradeStatusCodeIn(
+                title, tradeStatusCodeArray , pageable).map(
                 article -> articleConverter.toArticleBriefViewResponse(article, false)
             );
             return articleBriefViewResponses;
         }
 
         Member currentMember = memberRepository.findByPrincipal(authentication.loginId).get();
-        Page<ArticleBriefViewResponse> titles = articleRepository.findByTitleIgnoreCaseContains(
-            title, pageable).map(
+
+        Page<ArticleBriefViewResponse> titles = articleRepository.findByTitleIgnoreCaseContainsAndTradeStatusCodeIn(
+            title, tradeStatusCodeArray, pageable).map(
             article -> makeBriefViewResponseWithLikeInfo(article, currentMember)
         );
         return titles;


### PR DESCRIPTION
- 아티클 조회시 판매 완료된 아티클(상품) 제외한 결과를 반환하도록 수정
  - 쿼리 메서드 findByTitleIgnoreCaseContains -> findByTitleIgnoreCaseContainsAndTradeStatusCodeIn(Array [] tradeStatusCode) 

- 2차 pr 
  - 피드백 반영 : token Optaion.ofNullable() 적용
  - filter 검색 Query DSL에도 판매 완료된 아티클 제외하고 조회, 카운트 하도록 메서드 수정
  
resolves #123 